### PR TITLE
Fix router branch on Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "byebug", require: false
-gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "feature/tree-rewrite"
+gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "unstable"


### PR DESCRIPTION
With a clear bundler cache this fail because branch feature/tree-rewrite
has been merged in unstable

cf https://github.com/hanami/router/pull/199

Thanks for your work and talk in Paris.rb

Cheers,
Laurent