### PR TITLE
Simplify Hanami::Api::Block::Context#call

### DIFF
--- a/lib/hanami/api/block/context.rb
+++ b/lib/hanami/api/block/context.rb
@@ -130,7 +130,6 @@ module Hanami
         # @since 0.1.0
         # @api private
         #
-        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         def call
           case caught
@@ -147,15 +146,14 @@ module Hanami
             #       which results in a bug.
             [status, headers, [self.body || http_status(status)]]
             # rubocop:enable Style/RedundantSelf
-            in [Integer, String] => response
-            [response[0], headers, [response[1]]]
-            in [Integer, Hash, String] => response
-            headers.merge!(response[1])
-            [response[0], headers, [response[2]]]
+            in [Integer => status, String => body]
+            [status, headers, [body]]
+            in [Integer => status, Hash => caught_headers, String => body]
+            headers.merge!(caught_headers)
+            [status, headers, [body]]
           end
         end
         # rubocop:enable Metrics/MethodLength
-        # rubocop:enable Metrics/AbcSize
 
         private
 


### PR DESCRIPTION
With more extensive use of as-patterns, the `Hanami::Api::Block::Context#call` method can be simplified to such an extent that one AbcSize RuboCop violation does not longer exist and the `rubocop:disable` directive can be dropped.

Performance-wise, old and new styles of pattern matching are very similar. Benchmpark/ips reports that the difference between them "falls within error".

This is the microbenchmark code I used:

```ruby
# frozen_string_literal: true

require 'benchmark/ips'

def call1(caught)
  case caught
  in [Integer, Hash, String] => response
  @h = response[1]
  @s = response[0]
  @b = response[2]
  end
end

def call2(caught)
  case caught
  in [Integer => status, Hash => h, String => body]
  @h = h
  @s = status
  @b = body
  end
end

caught = [200, {}, 'body']

Benchmark.ips do |x|
  x.report('original') { call1(caught) }
  x.report('new') { call2(caught) }
  x.compare!
end

__END__

Warming up --------------------------------------
            original   288.026k i/100ms
                 new   288.478k i/100ms
Calculating -------------------------------------
            original      2.884M (± 2.0%) i/s -     14.689M in   5.096077s
                 new      2.923M (± 1.3%) i/s -     14.712M in   5.033728s

Comparison:
                 new:  2923260.2 i/s
            original:  2883644.7 i/s - same-ish: difference falls within error
```

On a bigger scale, the difference is going to be even less noticeable. 