### PR TITLE
Introduce Hanami::API::DSL

### DIFF
--- a/lib/hanami/api.rb
+++ b/lib/hanami/api.rb
@@ -9,21 +9,15 @@ module Hanami
     require "hanami/api/error"
     require "hanami/api/router"
     require "hanami/api/middleware"
+    require "hanami/api/dsl"
 
     # @since 0.1.0
     # @api private
     def self.inherited(app)
       super
 
-      app.class_eval do
-        @router = Router.new
-      end
-    end
-
-    class << self
-      # @since 0.1.1
-      # @api private
-      attr_reader :router
+      app.extend(DSL::ClassMethods)
+      app.include(DSL::InstanceMethods)
     end
 
     # Defines a named root route (a GET route for "/")
@@ -290,29 +284,6 @@ module Hanami
     #   end
     def self.use(middleware, *args, &blk)
       @router.use(middleware, *args, &blk)
-    end
-
-    # @since 0.1.0
-    def initialize(router: self.class.router.dup)
-      @router = router
-
-      freeze
-    end
-
-    # @since 0.1.0
-    def freeze
-      @app = @router.to_rack_app
-      @url_helpers = @router.url_helpers
-      @router.remove_instance_variable(:@url_helpers)
-      remove_instance_variable(:@router)
-      @url_helpers.freeze
-      @app.freeze
-      super
-    end
-
-    # @since 0.1.0
-    def call(env)
-      @app.call(env)
     end
 
     # TODO: verify if needed here on in block context

--- a/lib/hanami/api/dsl.rb
+++ b/lib/hanami/api/dsl.rb
@@ -37,6 +37,8 @@ module Hanami
       # @since 0.2.0
       # @api private
       def self.extended(app)
+        super
+
         app.extend(ClassMethods)
         app.extend(ClassMethods::Routes)
         app.include(InstanceMethods)

--- a/lib/hanami/api/dsl.rb
+++ b/lib/hanami/api/dsl.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Hanami
+  class API
+    # Expose Hanami::API features to third party frameworks that need to expose
+    # a routing DSL.
+    #
+    # @since 0.2.0
+    #
+    # @example
+    #   # framework.rb
+    #    require "hanami/api"
+    #
+    #    module Framework
+    #      class App
+    #        def self.inherited(base)
+    #          super
+    #          base.extend(Hanami::API::DSL)
+    #        end
+    #      end
+    #    end
+    #
+    #    # app.rb
+    #    require "framework/app"
+    #
+    #    class MyApp < Framework::App
+    #      routes do
+    #        root { "Hello, World!" }
+    #      end
+    #    end
+    #
+    #    # config.ru
+    #    require_relative "./app"
+    #
+    #    run MyApp.new
+    module DSL
+      # @since 0.2.0
+      # @api private
+      def self.extended(app)
+        app.extend(ClassMethods)
+        app.extend(ClassMethods::Routes)
+        app.include(InstanceMethods)
+      end
+
+      # @since 0.2.0
+      # @api private
+      module ClassMethods
+        # @since 0.2.0
+        # @api private
+        attr_reader :router
+
+        # @since 0.2.0
+        # @api private
+        def self.extended(app)
+          super
+
+          app.class_eval do
+            @router = Router.new
+          end
+        end
+
+        # @since 0.2.0
+        # @api private
+        module Routes
+          # A block to define application routes
+          #
+          # This is ONLY available for third-party frameworks that use
+          # Hanami::API DSL.
+          #
+          # If you use Hanami::API directly, this method isn't available.
+          #
+          # @param blk [Proc] the block to define the routes
+          #
+          # @see Hanami::API::Router
+          #
+          # @since 0.2.0
+          # @api public
+          def routes(&blk)
+            router.instance_eval(&blk)
+          end
+        end
+      end
+
+      module InstanceMethods
+        # Initialize the app
+        #
+        # @param router [Hanami::API::Router] the application router
+        #
+        # @since 0.2.0
+        # @api public
+        def initialize(router: self.class.router.dup)
+          @router = router
+
+          freeze
+        end
+
+        # @since 0.2.0
+        # @api private
+        def freeze
+          @app = @router.to_rack_app
+          @url_helpers = @router.url_helpers
+          @router.remove_instance_variable(:@url_helpers)
+          remove_instance_variable(:@router)
+          @url_helpers.freeze
+          @app.freeze
+          super
+        end
+
+        # Compatibility with Rack protocol
+        #
+        # @param env [Hash] a Rack env for the current request
+        #
+        # @since 0.2.0
+        # @api public
+        def call(env)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Feature

Introduce `Hanami::API::DSL` which gives the ability to other frameworks to use the `Hanami::API` DSL.

## Example

Imagine you're building a web framework, or simply you need a routing DSL. You declare a superclass like this:

```ruby
# framework.rb
require "hanami/api"

module Framework
  class App
    def self.inherited(base)
      super
      base.extend(Hanami::API::DSL)
    end
  end
end
```

Then in your app, you inherit from your superclass, which has now a `.routes` class method that can wrap all the routes. Within that block you have all the Hanami::API methods available.

```ruby
 # app.rb
require "framework/app"

class MyApp < Framework::App
  routes do
    root { "Hello, World!" }
  end
end
```

In `config.ru` (for Rack web servers), you just initialize your app.

```ruby
# config.ru
require_relative "./app"

run MyApp.new
```