### PR TITLE
Implement streamed responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Minimal, extremely fast, lightweight Ruby framework for HTTP APIs.
     - [Rack endpoint](#rack-endpoint)
     - [Block endpoint](#block-endpoint)
       * [String (body)](#string-body)
+      * [Enumerator (body)](#enumerator-body)
       * [Integer (status code)](#integer-status-code)
       * [Integer, String (status code, body)](#integer-string-status-code-body)
+      * [Integer, Enumerator (status code, body)](#integer-enumerator-status-code-body)
       * [Integer, Hash, String (status code, headers, body)](#integer-hash-string-status-code-headers-body)
+      * [Integer, Hash, Enumerator (status code, headers, body)](#integer-hash-enumerator-status-code-headers-body)
   + [Block context](#block-context)
     - [env](#env)
     - [status](#status)
@@ -179,6 +182,16 @@ end
 
 It will return `[200, {}, ["Hello, world"]]`
 
+##### Enumerator (body)
+
+```ruby
+get "/" do
+  Enumerator.new { ... }
+end
+```
+
+It will return `[200, {}, Enumerator]`, see [Streamed Responses](#streamed-responses)
+
 ##### Integer (status code)
 
 ```ruby
@@ -199,6 +212,16 @@ end
 
 It will return `[401, {}, ["You shall not pass"]]`
 
+##### Integer, Enumerator (status code, body)
+
+```ruby
+get "/" do
+  [401, Enumerator.new { ... }]
+end
+```
+
+It will return `[401, {}, Enumerator]`, see [Streamed Responses](#streamed-responses)
+
 ##### Integer, Hash, String (status code, headers, body)
 
 ```ruby
@@ -208,6 +231,16 @@ end
 ```
 
 It will return `[401, {"X-Custom-Header" => "foo"}, ["You shall not pass"]]`
+
+##### Integer, Hash, Enumerator (status code, headers, body)
+
+```ruby
+get "/" do
+  [401, {"X-Custom-Header" => "foo"}, Enumerator.new { ... }]
+end
+```
+
+It will return `[401, {"X-Custom-Header" => "foo"}, Enumerator]`, see [Streamed Responses](#streamed-responses)
 
 ### Block context
 
@@ -274,6 +307,14 @@ get "/" do
 end
 ```
 
+Set HTTP response body using a [Streamed Response](#streamed-responses)
+
+```ruby
+get "/" do
+  body Enumerator.new { ... }
+end
+```
+
 #### params
 
 Access params for current request
@@ -308,6 +349,14 @@ end
 ```
 
 It sets a Rack response: `[401, {}, ["You shall not pass"]]`
+
+You can also use a [Streamed Response](#streamed-responses) here
+
+```ruby
+get "/authenticate" do
+  halt(401, Enumerator.new { ... })
+end
+```
 
 #### redirect
 
@@ -362,6 +411,15 @@ end
 get "/user/:id" do
   user = UserRepository.new.find(params[:id])
   json(user, "application/vnd.api+json")
+end
+```
+
+If you want a [Streamed Response](#streamed-responses)
+
+```ruby
+get "/users" do
+  users = Enumerator.new { ... }
+  json(users)
 end
 ```
 

--- a/lib/hanami/api/block/context.rb
+++ b/lib/hanami/api/block/context.rb
@@ -181,7 +181,7 @@ module Hanami
           Rack::Utils::HTTP_STATUS_CODES.fetch(code)
         end
 
-        # @since ?
+        # @since x.x.x
         # @api private
         def json_enum(collection)
           Enumerator.new do |yielder|

--- a/lib/hanami/api/block/context.rb
+++ b/lib/hanami/api/block/context.rb
@@ -124,7 +124,12 @@ module Hanami
         #   end
         def json(object, mime = "application/json")
           headers["Content-Type"] = mime
-          JSON.generate(object)
+          case object
+            in Enumerator => collection
+            json_enum(collection)
+            else
+            JSON.generate(object)
+          end
         end
 
         # @since 0.1.0
@@ -134,6 +139,8 @@ module Hanami
           case caught
             in String => body
             [status, headers, [body]]
+            in Enumerator => body
+            [status, headers, body]
             in Integer => status
             # rubocop:disable Style/RedundantSelf
             #
@@ -147,9 +154,14 @@ module Hanami
             # rubocop:enable Style/RedundantSelf
             in [Integer => status, String => body]
             [status, headers, [body]]
+            in [Integer => status, Enumerator => body]
+            [status, headers, body]
             in [Integer => status, Hash => caught_headers, String => body]
             headers.merge!(caught_headers)
             [status, headers, [body]]
+            in [Integer => status, Hash => caught_headers, Enumerator => body]
+            headers.merge!(caught_headers)
+            [status, headers, body]
           end
         end
 
@@ -167,6 +179,20 @@ module Hanami
         # @api private
         def http_status(code)
           Rack::Utils::HTTP_STATUS_CODES.fetch(code)
+        end
+
+        # @since ?
+        # @api private
+        def json_enum(collection)
+          Enumerator.new do |yielder|
+            yielder << "["
+            collection.each_with_index do |item, i|
+              yielder << "," if i.positive?
+              yielder << JSON.generate(item)
+            end
+          ensure
+            yielder << "]"
+          end
         end
       end
     end


### PR DESCRIPTION
With this, you are able deliver partial content as soon as it's
available, for example on long running data retrieval actions.

Also, the time to first byte is greatly reduced which might prevent
timeouts somewhere between server and client (for example by a proxy).

I know hanami-controller provides similar functionality but that
dependency shouldn't be necessary for an api only application.
I hope, I didn't miss any other way this could have been activated
somehow with existing hanami code.