### PR TITLE
Hanami::API routes inspector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "byebug", require: false
-gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "hanami-api-inspector-compat"
+gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "unstable"

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "byebug", require: false
-gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "unstable"
+gem "hanami-router", git: "https://github.com/hanami/router.git", branch: "hanami-api-inspector-compat"

--- a/lib/hanami/api/dsl.rb
+++ b/lib/hanami/api/dsl.rb
@@ -117,6 +117,16 @@ module Hanami
         def call(env)
           @app.call(env)
         end
+
+        # Printable routes
+        #
+        # @return [String] printable routes
+        #
+        # @since x.x.x
+        # @api public
+        def to_inspect
+          @app.to_inspect
+        end
       end
     end
   end

--- a/lib/hanami/api/middleware/app.rb
+++ b/lib/hanami/api/middleware/app.rb
@@ -28,12 +28,19 @@ module Hanami
           end
 
           @trie.freeze
+          @inspector = app.inspector.freeze
         end
 
         # @since 0.1.1
         # @api private
         def call(env)
           @trie.find(env["PATH_INFO"]).call(env)
+        end
+
+        # @since x.x.x
+        # @api private
+        def to_inspect
+          @inspector.call
         end
       end
     end

--- a/lib/hanami/api/router.rb
+++ b/lib/hanami/api/router.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
 require "hanami/router"
+require "hanami/router/inspector"
 require "hanami/api/block/context"
 
 module Hanami
   class API
     # @since 0.1.0
     class Router < ::Hanami::Router
+      # @since x.x.x
+      # @api private
+      attr_reader :inspector
+
       # @since 0.1.0
       # @api private
-      def initialize(block_context: Block::Context, **kwargs)
-        super(block_context: block_context, **kwargs)
+      def initialize(block_context: Block::Context, inspector: Inspector.new, **kwargs)
+        super(block_context: block_context, inspector: inspector, **kwargs)
         @stack = Middleware::Stack.new(@path_prefix.to_s)
       end
 
@@ -33,6 +38,16 @@ module Hanami
       # @api private
       def to_rack_app
         @stack.finalize(self)
+      end
+
+      # Returns formatted routes
+      #
+      # @return [String] formatted routes
+      #
+      # @since x.x.x
+      # @api private
+      def to_inspect
+        @inspector.call
       end
     end
   end

--- a/spec/unit/hanami/api/to_inspect_spec.rb
+++ b/spec/unit/hanami/api/to_inspect_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::API do
+  describe "#to_inspect" do
+    context "without Rack middleware" do
+      subject do
+        Class.new(described_class) do
+          root { "Hello, World!" }
+        end.new
+      end
+
+      it "inspects defined routes" do
+        expected = [
+          "GET     /                             (block)                       as :root"
+        ]
+
+        actual = subject.to_inspect
+        expected.each do |route|
+          expect(actual).to include(route)
+        end
+      end
+    end
+
+    context "with Rack middleware" do
+      subject do
+        m = middleware
+
+        Class.new(described_class) do
+          use m
+          root { "Hello, World!" }
+        end.new
+      end
+
+      let(:middleware) do
+        Class.new do
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+          end
+        end
+      end
+
+      it "inspects defined routes" do
+        expected = [
+          "GET     /                             (block)                       as :root"
+        ]
+
+        actual = subject.to_inspect
+        expected.each do |route|
+          expect(actual).to include(route)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Feature

  * Introduce `Hanami::API#to_inspect` which returns a `String` with printable routes

## Technical notes

  * Contrary to `hanami-router`, Hanami::API inspector couldn't be lazy because the class DSL that defines the routes cannot be re-evaluated like in the case of `Hanami::Router`, where the routes definition happens at the instance level.

---

Ref https://github.com/hanami/router/pull/208
Ref https://github.com/hanami/router/pull/212