### PR TITLE
Hanami::API::Container

### DIFF
--- a/hanami-api.gemspec
+++ b/hanami-api.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rubocop", "~> 0.86"
   spec.add_development_dependency "yard", "~> 0.9"
+
+  spec.add_development_dependency "dry-system", "~> 0.19"
 end

--- a/hanami-api.gemspec
+++ b/hanami-api.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.86"
   spec.add_development_dependency "yard", "~> 0.9"
 
-  spec.add_development_dependency "dry-system", "~> 0.19"
+  spec.add_development_dependency "dry-container", "~> 0.7"
+  spec.add_development_dependency "dry-auto_inject", "~> 0.7"
 end

--- a/lib/hanami/api/container.rb
+++ b/lib/hanami/api/container.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "dry/system/container"
+require "dry/system/components"
+require "dry/auto_inject"
+require "dry/types"
+
+module Hanami
+  class API
+    module Container
+      def self.extended(app)
+        super
+        container = Class.new(Dry::System::Container) do
+          configure do |config|
+            config.root Pathname.new(Dir.pwd)
+          end
+
+          use :env, inferrer: -> { ENV.fetch("HANAMI_ENV", :development).to_sym }
+        end
+
+        types = Module.new { include Dry.Types() }
+        app.const_set(:Types, types)
+        app.const_set(:Container, container)
+        app.const_set(:Deps, Dry::AutoInject(container))
+        app.class_eval do
+          @container = self::Container
+        end
+
+        app.extend(ClassMethods)
+        app.include(InstanceMethods)
+      end
+
+      module ClassMethods
+        attr_reader :container
+
+        def configure(...)
+          container.configure(...)
+        end
+
+        def settings(&blk)
+          container.boot(:settings, from: :system) do
+            settings(&blk)
+          end
+        end
+
+        def register(...)
+          container.register(...)
+        end
+      end
+
+      module InstanceMethods
+        def freeze
+          container = self.class.container
+          deps = self.class::Deps
+          block = self.class::BlockContext
+          container.finalize!
+
+          block.class_eval do
+            include deps[*container.keys]
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/api/container.rb
+++ b/lib/hanami/api/container.rb
@@ -1,26 +1,22 @@
 # frozen_string_literal: true
 
-require "pathname"
-require "dry/system/container"
-require "dry/system/components"
-require "dry/auto_inject"
-require "dry/types"
+begin
+  require "dry/container"
+  require "dry/auto_inject"
+rescue LoadError
+  puts "Hanami::API::Container requires `dry-container' and `dry-auto_inject' gems. Add them to your `Gemfile'."
+  raise
+end
 
 module Hanami
   class API
     module Container
       def self.extended(app)
         super
-        container = Class.new(Dry::System::Container) do
-          configure do |config|
-            config.root Pathname.new(Dir.pwd)
-          end
-
-          use :env, inferrer: -> { ENV.fetch("HANAMI_ENV", :development).to_sym }
+        container = Class.new(Dry::Container) do
+          extend Dry::Container::Mixin
         end
 
-        types = Module.new { include Dry.Types() }
-        app.const_set(:Types, types)
         app.const_set(:Container, container)
         app.const_set(:Deps, Dry::AutoInject(container))
         app.class_eval do
@@ -33,16 +29,6 @@ module Hanami
 
       module ClassMethods
         attr_reader :container
-
-        def configure(...)
-          container.configure(...)
-        end
-
-        def settings(&blk)
-          container.boot(:settings, from: :system) do
-            settings(&blk)
-          end
-        end
 
         def register(...)
           container.register(...)

--- a/lib/hanami/api/container.rb
+++ b/lib/hanami/api/container.rb
@@ -13,7 +13,7 @@ module Hanami
     module Container
       def self.extended(app)
         super
-        container = Class.new(Dry::Container) do
+        container = Class.new do
           extend Dry::Container::Mixin
         end
 

--- a/spec/integration/hanami/api/container_spec.rb
+++ b/spec/integration/hanami/api/container_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "hanami/api/container"
+
+RSpec.describe Hanami::API do
+  describe "Container" do
+    let(:app) { Rack::MockRequest.new(api) }
+
+    let(:api) do
+      unless defined?(Upcase)
+        class Upcase
+          def call(string)
+            string.to_s.upcase
+          end
+        end
+      end
+
+      Class.new(described_class) do
+        extend Hanami::API::Container
+
+        register "upcase" do
+          Upcase.new
+        end
+
+        helpers do
+          def up(string)
+            upcase.call(string)
+          end
+        end
+
+        root do
+          upcase.call("hello")
+        end
+
+        get "/up" do
+          up("world")
+        end
+      end.new
+    end
+
+    it "has access to registered component" do
+      response = app.get("/", lint: true)
+
+      expect(response.status).to  eq(200)
+      expect(response.headers).to eq({"Content-Length" => "5"})
+      expect(response.body).to    eq("HELLO")
+    end
+
+    it "makes registered component accessible from headers" do
+      response = app.get("/up", lint: true)
+
+      expect(response.status).to  eq(200)
+      expect(response.headers).to eq({"Content-Length" => "5"})
+      expect(response.body).to    eq("WORLD")
+    end
+  end
+end


### PR DESCRIPTION
## Feature

Allow to register deps to be used within the _block context_. 

ℹ️ **Convention**: the name of the **registration key** is the same method that can be used in the _block context_. Example: `register :redis` will make the `redis` method available in _block context_.

💡  **Good to know:** registered deps can be used in helpers. See https://github.com/hanami/api/pull/26

## Examples

⚠️ This feature requires to **manually bundle** `dry-container` and `dry-auto_inject` gems.

```ruby
# Gemfile

gem "hanami-api"

# Manually add those gems to your Gemfile
gem "dry-container"
gem "dry-auto_inject"
```

### Scenario 1: register and use a dependency directly in block endpoints.

```ruby
# frozen_string_literal: true
require "hanami/api"
require "hanami/api/container"

require "logger"

class MyApp < Hanami::API
  extend Hanami::API::Container+

  register :logger do
    Logger.new($stdout)
  end

  root do
    logger.info("request GET /")

    "hello"
  end
end
```

### Scenario 2: register a dependency and use it in helpers. See https://github.com/hanami/api/pull/26

```ruby
# frozen_string_literal: true
require "hanami/api"
require "hanami/api/container"

require "logger"

class MyApp < Hanami::API
  extend Hanami::API::Container

  register :logger do
    Logger.new($stdout)
  end

  helpers do
    def redirect_to_root
      logger.info("redirect to GET /")

      redirect "/"
    end
  end

  root do
    logger.info("request GET /")

    "hello"
  end

  get "/legacy" do
    redirect_to_root
  end
end
```