### PR TITLE
Add line to Gemfile for Rack-compatible server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ __Hanami::API__ supports Ruby (MRI) 2.7+
 
 ## Installation
 
-Add this line to your application's `Gemfile`:
+Add these lines to your application's `Gemfile`:
 
 ```ruby
 gem "hanami-api"
+gem "puma" # or "webrick", or "thin", "falcon"
 ```
 
 And then execute:


### PR DESCRIPTION
WEBrick was removed from Ruby in 3.0, so we need to specify a server.

Happy to add a high-level integration test for this (either for `puma` or all of them)


Without this, users get the following error when running `bundle exec rackup`:

```
/Users/sean/.gem/ruby/3.0.3/gems/rack-2.2.3/lib/rack/handler.rb:45:in `pick': Couldn't find handler for: puma, thin, falcon, webrick. (LoadError)
```