### PR TITLE
Only support Ruby 3.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby:
           - "3.0"
-          - "2.7"
+          - "3.1"
     env:
       CODACY_RUN_LOCAL: true
       CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimal, extremely fast, lightweight Ruby framework for HTTP APIs.
 
 ## Rubies
 
-__Hanami::API__ supports Ruby (MRI) 2.7+
+__Hanami::API__ supports Ruby (MRI) 3.0+
 
 ## Installation
 

--- a/hanami-api.gemspec
+++ b/hanami-api.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Hanami API"
   spec.description   = "Extremely fast and lightweight HTTP API"
   spec.homepage      = "http://rubygems.org"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
We updated the requirements for the other Hanami gems, including `hanami-router` to 3.0+. So, Ruby 2.7+ was failing to install, since the Gemfile requires using the `main` version of `hanami-router`.

I removed 2.7 from CI and added 3.1 to ensure we have that coverage.