### PR TITLE
Fix rendering of the bottom section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ Then you can use its methods like `get` and `last_response`, e.g.:
     expect(last_response.status).to eq 200
   end
 end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -663,10 +663,9 @@ include Rack::Test::Methods
 Then you can use its methods like `get` and `last_response`, e.g.:
 
 ```ruby
-  it "returns the status 200" do
-    get "/"
-    expect(last_response.status).to eq 200
-  end
+it "returns the status 200" do
+  get "/"
+  expect(last_response.status).to eq 200
 end
 ```
 


### PR DESCRIPTION
Without this fix, the Development and Contributing sections are part of the code block.

![diff](https://user-images.githubusercontent.com/193455/156598498-46008c6e-da6b-4bec-b6c5-3ae5386a658f.png)

And yes, I made it all the way to the end of the README !