### PR TITLE
Fix code example for testing section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,14 +627,13 @@ The keys that (based on the Rack standard) `Hanami::API` uses for routing are:
 
 For example, a spec for the basic app in the [Usage section](https://github.com/hanami/api#usage) could be:
 
-```
+```ruby
 require "my_project/app"
 
 RSpec.describe App do
   describe "#call" do
     it "returns successfully" do
-      env = {"PATH_INFO" => "/", "REQUEST_METHOD" => "GET"]}
-      response = subject.call({"PATH_INFO" => "/", "REQUEST_METHOD" => "GET"]})
+      response = subject.call({"PATH_INFO" => "/", "REQUEST_METHOD" => "GET"})
       expect(response).to eq([200, {}, ["Hello, world"]])
     end
   end


### PR DESCRIPTION
I noticed that a code example for "Testing" section is broken: it declares a variable that is never used and contains a syntax error. This PR contains a fix to the example.