### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ Requests per second hitting the 1st (and only route) and the 10,000th route to m
 Create `config.ru` at the root of your project:
 
 ```ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/api"
 
@@ -522,8 +520,6 @@ You can use `.helpers` multiple times in the same app.
 To mount a Rack middleware it's possible with `.use`
 
 ```ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/api"
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/api"
 

--- a/hanami-api.gemspec
+++ b/hanami-api.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "lib/hanami/api/version"
 
 Gem::Specification.new do |spec|

--- a/lib/hanami/api.rb
+++ b/lib/hanami/api.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Hanami::API
   #

--- a/lib/hanami/api/block/context.rb
+++ b/lib/hanami/api/block/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/block"
 require "rack/utils"
 require "json"

--- a/lib/hanami/api/dsl.rb
+++ b/lib/hanami/api/dsl.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class API
     # Expose Hanami::API features to third party frameworks that need to expose

--- a/lib/hanami/api/error.rb
+++ b/lib/hanami/api/error.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class API
     # @since 0.1.0

--- a/lib/hanami/api/middleware.rb
+++ b/lib/hanami/api/middleware.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/app"
 
 module Hanami

--- a/lib/hanami/api/router.rb
+++ b/lib/hanami/api/router.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router"
 require "hanami/router/inspector"
 require "hanami/api/block/context"

--- a/lib/hanami/api/version.rb
+++ b/lib/hanami/api/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class API
     # @since 0.1.0

--- a/spec/integration/hanami/api/block_spec.rb
+++ b/spec/integration/hanami/api/block_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "Block" do
     let(:app) { Rack::MockRequest.new(api) }

--- a/spec/integration/hanami/api/helpers_spec.rb
+++ b/spec/integration/hanami/api/helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe ".helpers" do
     let(:app) { Rack::MockRequest.new(api) }

--- a/spec/integration/hanami/api/middleware_spec.rb
+++ b/spec/integration/hanami/api/middleware_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "Rack middleware" do
     let(:app) { Rack::MockRequest.new(api) }

--- a/spec/integration/hanami/api/streamed_response_spec.rb
+++ b/spec/integration/hanami/api/streamed_response_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "Streamed Response" do
     let(:app) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "./support/rspec"
 require_relative "./support/http"
 require "rack/mock"

--- a/spec/support/http.rb
+++ b/spec/support/http.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module HTTP

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/unit/hanami/api/initialize_spec.rb
+++ b/spec/unit/hanami/api/initialize_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "#initialize" do
     let(:klass) do

--- a/spec/unit/hanami/api/middleware/stack_spec.rb
+++ b/spec/unit/hanami/api/middleware/stack_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API::Middleware::Stack do
   describe "#to_hash" do
     it "serializes to Hash" do

--- a/spec/unit/hanami/api/mount_spec.rb
+++ b/spec/unit/hanami/api/mount_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "mount" do
     subject do

--- a/spec/unit/hanami/api/redirect_spec.rb
+++ b/spec/unit/hanami/api/redirect_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "redirect" do
     subject do

--- a/spec/unit/hanami/api/route_options_spec.rb
+++ b/spec/unit/hanami/api/route_options_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "route options" do
     subject do

--- a/spec/unit/hanami/api/scope_spec.rb
+++ b/spec/unit/hanami/api/scope_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "scope" do
     subject do

--- a/spec/unit/hanami/api/to_inspect_spec.rb
+++ b/spec/unit/hanami/api/to_inspect_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "#to_inspect" do
     context "without Rack middleware" do

--- a/spec/unit/hanami/api/url_helpers_spec.rb
+++ b/spec/unit/hanami/api/url_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 
 RSpec.describe Hanami::API do

--- a/spec/unit/hanami/api/version_spec.rb
+++ b/spec/unit/hanami/api/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::API::VERSION" do
   it "returns version" do
     expect(Hanami::API::VERSION).to eq("0.3.0")

--- a/spec/unit/hanami/api_spec.rb
+++ b/spec/unit/hanami/api_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   subject do
     Class.new(described_class) do

--- a/spec/unit/hanami/http_methods_spec.rb
+++ b/spec/unit/hanami/http_methods_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "HTTP methods" do
     RSpec::Support::HTTP.supported_methods.each do |http_method|

--- a/spec/unit/hanami/root_spec.rb
+++ b/spec/unit/hanami/root_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::API do
   describe "#root" do
     subject do


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.